### PR TITLE
Update 08 - Applied OOP.fsx

### DIFF
--- a/Scripts/08 - Applied OOP.fsx
+++ b/Scripts/08 - Applied OOP.fsx
@@ -124,7 +124,7 @@ type TextBlock(text : string) =
     let words = text.Split([| ' ' |])
     
     member this.AverageWordLength =
-        words |> Array.map float |> Array.average
+        words |> Array.map String.length |> Array.map float |> Array.average
     
     member this.GetSlice(lowerBound : int option, upperBound : int option) =
         let words =


### PR DESCRIPTION
Hi,
AverageWordLength function did throw FormatException when trying to invoke sample textBlock.
Proposed change is what I think You meant this code should do.
